### PR TITLE
Validate enclosure URL

### DIFF
--- a/mailman-rss
+++ b/mailman-rss
@@ -32,6 +32,8 @@ import sys
 import tempfile
 import urllib2
 
+from urlparse import urlparse
+
 def get_parser():
     parser = optparse.OptionParser(usage="usage: %prog [options] <archive url>")
     parser.add_option("-c", "--count", default=25, type="int",
@@ -161,8 +163,10 @@ def print_rss(archive, mails):
             url = get_part_field(part, "url")
 
             if mime_type and size and url:
-                print '<enclosure url="%s" length="%s" type="%s" />' % \
-                    (url, size, mime_type)
+                o = urlparse(url)
+                if o.netloc:
+                    print '<enclosure url="%s" length="%s" type="%s" />' % \
+                        (url, size, mime_type)
 
         print '</item>'
 


### PR DESCRIPTION
Fix: generate only enclosures with valid URLs.

An enclosure URL can be invalid. For example, the URL can be surrounded by "<" and ">". A "<" in the URL makes the whole RSS XML invalid:

```
URL: <http://lists...
```

generates RSS:

```
<enclosure url="<http://lists...
```
